### PR TITLE
Add a reference to the Antlr paser that parsed a given phased unit, as discussed with Emmanuel.

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/context/PhasedUnit.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/context/PhasedUnit.java
@@ -19,6 +19,7 @@ import com.redhat.ceylon.compiler.typechecker.model.Setter;
 import com.redhat.ceylon.compiler.typechecker.model.TypeDeclaration;
 import com.redhat.ceylon.compiler.typechecker.model.TypedDeclaration;
 import com.redhat.ceylon.compiler.typechecker.model.Unit;
+import com.redhat.ceylon.compiler.typechecker.parser.CeylonParser;
 import com.redhat.ceylon.compiler.typechecker.tree.Tree;
 import com.redhat.ceylon.compiler.typechecker.tree.Validator;
 import com.redhat.ceylon.compiler.typechecker.util.AssertionVisitor;
@@ -39,6 +40,7 @@ public class PhasedUnit {
     private final ModuleBuilder moduleBuilder;
     private final Context context;
     private final String pathRelativeToSrcDir;
+    private CeylonParser parser; 
 
     public PhasedUnit(VirtualFile unitFile, VirtualFile srcDir, Tree.CompilationUnit cu, Package p, ModuleBuilder moduleBuilder, Context context) {
         this.compilationUnit = cu;
@@ -153,6 +155,14 @@ public class PhasedUnit {
 
     public Tree.CompilationUnit getCompilationUnit() {
         return compilationUnit;
+    }
+
+    public void setParser(CeylonParser parser) {
+      this.parser = parser;
+    }
+
+    public CeylonParser getParser() {
+      return parser;
     }
 
 }

--- a/src/com/redhat/ceylon/compiler/typechecker/context/PhasedUnits.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/context/PhasedUnits.java
@@ -122,6 +122,7 @@ public class PhasedUnits {
             CommonTree t = (CommonTree) r.getTree();
             Tree.CompilationUnit cu = new CustomBuilder().buildCompilationUnit(t);
             PhasedUnit phasedUnit = new PhasedUnit(file, srcDir, cu, p, moduleBuilder, context);
+            phasedUnit.setParser(parser);
             addPhasedUnit(file, phasedUnit);
 
         }


### PR DESCRIPTION
It is necessary to be able to implement functions that maintain the link between source code and AST tokens, which is a necessary basic feature of an IMP-based IDE. And this link can only be retrieved through the Antlr CommonTokenStream object returned by the Antlr Paser.
