### PR TITLE
In order to manage typechecking the additional units whose unresolved references could be resolved by the built file.

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
@@ -1922,6 +1922,7 @@ public class ExpressionVisitor extends Visitor {
         if (member==null) {
             that.addError("method or attribute does not exist: " +
                     name(that.getIdentifier()), 100);
+            unit.getUnresolvedReferences().add(that.getIdentifier());
         }
         else {
             that.setDeclaration(member);
@@ -1948,6 +1949,7 @@ public class ExpressionVisitor extends Visitor {
             if (member==null) {
                 that.addError("member method or attribute does not exist: " +
                         name(that.getIdentifier()), 100);
+                unit.getUnresolvedReferences().add(that.getIdentifier());
             }
             else {
                 that.setDeclaration(member);
@@ -2014,6 +2016,7 @@ public class ExpressionVisitor extends Visitor {
         if (type==null) {
             that.addError("type does not exist: " + 
                     name(that.getIdentifier()), 100);
+            unit.getUnresolvedReferences().add(that.getIdentifier());
         }
         else {
             that.setDeclaration(type);
@@ -2039,6 +2042,7 @@ public class ExpressionVisitor extends Visitor {
             if (type==null) {
                 that.addError("member type does not exist: " +
                         name(that.getIdentifier()), 100);
+                unit.getUnresolvedReferences().add(that.getIdentifier());
             }
             else {
                 that.setDeclaration(type);

--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/TypeVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/TypeVisitor.java
@@ -182,6 +182,7 @@ public class TypeVisitor extends Visitor {
         if (type==null) {
             that.addError("type declaration not found: " + 
                     name(that.getIdentifier()), 100);
+            unit.getUnresolvedReferences().add(that.getIdentifier());
         }
         else {
             ProducedType outerType = that.getScope().getDeclaringType(type);
@@ -215,6 +216,7 @@ public class TypeVisitor extends Visitor {
             if (type==null) {
                 that.addError("member type declaration not found: " + 
                         name(that.getIdentifier()), 100);
+                unit.getUnresolvedReferences().add(that.getIdentifier());
             }
             else {
                 if (!type.isVisible(that.getScope())) {

--- a/src/com/redhat/ceylon/compiler/typechecker/model/Unit.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/model/Unit.java
@@ -4,9 +4,13 @@ import static com.redhat.ceylon.compiler.typechecker.model.Util.producedType;
 import static com.redhat.ceylon.compiler.typechecker.model.Util.unionType;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+
+import com.redhat.ceylon.compiler.typechecker.tree.Tree.Identifier;
 
 public class Unit {
 
@@ -15,13 +19,18 @@ public class Unit {
     List<Declaration> declarations = new ArrayList<Declaration>();
     String filename;
     List<ImportList> importLists = new ArrayList<ImportList>();
-
+    Set<Identifier> unresolvedReferences = new HashSet<Identifier>();
+    
     public List<Import> getImports() {
         return imports;
     }
 
     public List<ImportList> getImportLists() {
         return importLists;
+    }
+
+    public Set<Identifier> getUnresolvedReferences() {
+        return unresolvedReferences;
     }
 
     public Package getPackage() {


### PR DESCRIPTION
Could be optimized later in order to better select the additional files to typecheck 
