### PR TITLE
Ability to override the default user's repository path

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/io/VFSArtifactProvider.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/io/VFSArtifactProvider.java
@@ -13,9 +13,15 @@ public class VFSArtifactProvider implements ArtifactProvider {
     private final VFS vfs;
 
     public VFSArtifactProvider(VFS vfs) {
-        File home = new File( System.getProperty("user.home") );
-        File ceylon = new File( home, ".ceylon" );
-        File repo = new File( ceylon, "repo" );
+        File repo;
+        String ceylonUserRepo = System.getProperty("ceylon.user.repo");
+        if (ceylonUserRepo == null) {
+            File home = new File( System.getProperty("user.home") );
+            File ceylon = new File( home, ".ceylon" );
+            repo = new File( ceylon, "repo" );
+        } else {
+            repo = new File( ceylonUserRepo );
+        }
         repo.mkdirs();
         homeRepo = vfs.getFromFile(repo);
         this.vfs = vfs;


### PR DESCRIPTION
Small temporary fix needed for the JS compiler to be able to override the user's repository path.
This is because on OpenShift we don't have write access to $HOME
This should be looked at again after we have properly integrated the module resolver into the type checker.
