### PR TITLE
Remove warnings about higher order function and method specifier support

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
@@ -451,9 +451,9 @@ public class DeclarationVisitor extends Visitor {
     @Override
     public void visit(Tree.MethodDeclaration that) {
         super.visit(that);
-        if ( that.getSpecifierExpression()!=null ) {
-            that.addWarning("method definition by reference is not yet supported");
-        }
+        //if ( that.getSpecifierExpression()!=null ) {
+        //    that.addWarning("method definition by reference is not yet supported");
+        //}
         if ( that.getDeclarationModel().isFormal() && that.getSpecifierExpression()!=null ) {
             that.addError("formal methods may not have a method reference");
         }
@@ -546,7 +546,7 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         exitScope(o);
         parameterList.getParameters().add(p);
-        that.addWarning("higher order methods are not yet supported");
+        //that.addWarning("higher order methods are not yet supported");
     }
 
     @Override

--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
@@ -2579,7 +2579,7 @@ public class ExpressionVisitor extends Visitor {
                 that.setTypeModel(t);
                 if (!withinAnnotation && term instanceof Tree.MemberOrTypeExpression &&
                         ((Tree.MemberOrTypeExpression) term).getDeclaration() instanceof Functional) {
-                    that.addWarning("callable references (first-class functions) not yet supported");
+                    //that.addWarning("callable references (first-class functions) not yet supported");
                 }
             }
         }


### PR DESCRIPTION
Remove warnings about higher order function and method specifier support for M2. Retain warnings about multiple parameter lists. 
