### PR TITLE
Disable warning about inner interfaces

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
@@ -272,9 +272,9 @@ public class DeclarationVisitor extends Visitor {
         Scope o = enterScope(i);
         super.visit(that);
         exitScope(o);
-        if (!i.isToplevel()) {
+        /*if (!i.isToplevel()) {
             that.addWarning("inner interfaces are not yet supported");
-        }
+        }*/
         /*if ( that.getCaseTypes()!=null ) {
             that.addWarning("interfaces with enumerated cases not yet supported");
         }*/


### PR DESCRIPTION
ceylon/ceylon.language@9b2b846e7199b5f0aedef5a084940b4ca3eb8cb4 added tests using inner interfaces, which the typechecker objects to, causing compilation of those tests to fail. This patch removes that "warning" and should let those tests at least compile.
