### PR TITLE
Fix for #208: forbid named invocation of java methods

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
@@ -1437,6 +1437,13 @@ public class ExpressionVisitor extends Visitor {
                 //pull the return type out of the Callable
                 that.setTypeModel(ct.getTypeArgumentList().get(0));
             }
+            if(that.getNamedArgumentList() != null){
+                List<ParameterList> parameterLists = dec.getParameterLists();
+                if(!parameterLists.isEmpty()
+                        && !parameterLists.get(0).isNamedParametersSupported()) {
+                    that.addError("named invocations of Java methods not supported");
+                }
+            }
             if (dec.isAbstraction()) {
                 //nothing to check the argument types against
                 //that.addError("no matching overloaded declaration");
@@ -1467,8 +1474,10 @@ public class ExpressionVisitor extends Visitor {
                 checkPositionalArguments(pl, prf, that.getPositionalArgumentList());
             }
             if ( that.getNamedArgumentList()!=null ) {
-                that.getNamedArgumentList().getNamedArgumentList().setParameterList(pl);
-                checkNamedArguments(pl, prf, that.getNamedArgumentList());
+                if(pl.isNamedParametersSupported()) {
+                    that.getNamedArgumentList().getNamedArgumentList().setParameterList(pl);
+                    checkNamedArguments(pl, prf, that.getNamedArgumentList());
+                }
             }
         }
     }
@@ -2312,7 +2321,8 @@ public class ExpressionVisitor extends Visitor {
     
     private void checkOverloadedReference(Tree.MemberOrTypeExpression that) {
         if (that.getDeclaration() instanceof Functional &&
-                ((Functional)that.getDeclaration()).isAbstraction()) {
+                ((Functional)that.getDeclaration()).isAbstraction() &&
+                that.getSignature() != null) {
             that.addError("ambiguous reference to overloaded method or class: " +
                     that.getDeclaration().getName());
         }

--- a/src/com/redhat/ceylon/compiler/typechecker/model/ParameterList.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/model/ParameterList.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class ParameterList {
     
     private List<Parameter> parameters = new ArrayList<Parameter>();
+    private boolean supportsNamedParameters = true;
     
     public List<Parameter> getParameters() {
         return parameters;
@@ -14,6 +15,14 @@ public class ParameterList {
     @Override
     public String toString() {
         return "ParameterList" + parameters.toString();
+    }
+
+    public boolean isNamedParametersSupported() {
+        return supportsNamedParameters;
+    }
+
+    public void setNamedParametersSupported(boolean supportsNamedParameters) {
+        this.supportsNamedParameters = supportsNamedParameters;
     }
     
 }


### PR DESCRIPTION
This allows us to get much better error messages when people try to use named invocation of Java methods.
