### PR TITLE
Reallow spread and null-safe member operators on method references

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
@@ -3239,21 +3239,6 @@ public class ExpressionVisitor extends Visitor {
         if (that.getTypeModel()==null) {
             that.setTypeModel( defaultType() );
         }
-        if (that instanceof Tree.Expression) {
-            Tree.Expression expr = (Tree.Expression)that;
-            Tree.Term term = expr.getTerm();
-            if (term instanceof Tree.QualifiedMemberOrTypeExpression) {
-                Tree.QualifiedMemberOrTypeExpression qme = (Tree.QualifiedMemberOrTypeExpression)term;
-                if (qme.getMemberOperator() instanceof Tree.SpreadOp
-                        && qme.getTypeModel().getDeclaration().getQualifiedNameString().equals("ceylon.language.Callable")) {
-                    that.addWarning("spread method references not supported yet");
-                }
-                if (qme.getMemberOperator() instanceof Tree.SafeMemberOp
-                        && qme.getTypeModel().getDeclaration().getQualifiedNameString().equals("ceylon.language.Callable")) {
-                    that.addWarning("null-safe method references not supported yet");
-                }
-            }
-        }
     }
 
     @Override public void visit(Tree.Type that) {


### PR DESCRIPTION
Because these operators now work

This reverts commit b8a2ad541e0ed798aedcc45721b9d7d6981b6258.
