### PR TITLE
Added a possibility to filter which modules we want to parse/type-check

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/TypeChecker.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/TypeChecker.java
@@ -36,7 +36,8 @@ public class TypeChecker {
 
     //package level
     TypeChecker(VFS vfs, List<VirtualFile> srcDirectories, RepositoryManager repositoryManager, boolean verifyDependencies,
-            AssertionVisitor assertionVisitor, ModuleManagerFactory moduleManagerFactory, boolean verbose) {
+            AssertionVisitor assertionVisitor, ModuleManagerFactory moduleManagerFactory, boolean verbose,
+            List<String> moduleFilters) {
         long start = System.nanoTime();
         this.srcDirectories = srcDirectories;
         this.verbose = verbose;
@@ -45,6 +46,7 @@ public class TypeChecker {
         this.verifyDependencies = verifyDependencies;
         this.assertionVisitor = assertionVisitor;
         statsVisitor = new StatisticsVisitor();
+        phasedUnits.setModuleFilters(moduleFilters);
         phasedUnits.parseUnits(srcDirectories);
         long time = System.nanoTime()-start;
         if(verbose)

--- a/src/com/redhat/ceylon/compiler/typechecker/TypeCheckerBuilder.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/TypeCheckerBuilder.java
@@ -35,6 +35,7 @@ public class TypeCheckerBuilder {
     };
     private ModuleManagerFactory moduleManagerFactory;
     private RepositoryManager repositoryManager;
+    private List<String> moduleFilters = new ArrayList<String>();
 
     public TypeCheckerBuilder() {
     }
@@ -60,6 +61,12 @@ public class TypeCheckerBuilder {
         this.repositoryManager = repositoryManager;
     }
 
+    public TypeCheckerBuilder setModuleFilters(List<String> moduleFilters){
+        this.moduleFilters.clear();
+        this.moduleFilters.addAll(moduleFilters);
+        return this;
+    }
+    
     /**
      * @deprecated this is bad and a temporary hack
      *
@@ -101,7 +108,7 @@ public class TypeCheckerBuilder {
         if (repositoryManager == null) {
             repositoryManager = new RepositoryManagerBuilder( new LeakingLogger() ).buildRepository();
         }
-        return new TypeChecker(vfs, srcDirectories, repositoryManager, verifyDependencies, assertionVisitor, moduleManagerFactory, verbose);
+        return new TypeChecker(vfs, srcDirectories, repositoryManager, verifyDependencies, assertionVisitor, moduleManagerFactory, verbose, moduleFilters);
     }
 
 }


### PR DESCRIPTION
I need this to fix ceylon/ceylon-compiler#466: I couldn't find anything better to prevent the typechecker from parsing unwanted modules.

With this filter, it's now possible to use `ceylond` on a given module even if other modules in the same source path don't compile, or don't even parse.
