### PR TITLE
Issue-258 Generate warning for non-used private attributes and methods

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/TypeChecker.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/TypeChecker.java
@@ -58,11 +58,11 @@ public class TypeChecker {
     public PhasedUnits getPhasedUnits() {
         return phasedUnits;
     }
-    
+
     public List<PhasedUnits> getPhasedUnitsOfDependencies() {
         return phasedUnitsOfDependencies;
     }
-    
+
     public void setPhasedUnitsOfDependencies(
             List<PhasedUnits> phasedUnitsOfDependencies) {
         this.phasedUnitsOfDependencies = phasedUnitsOfDependencies;
@@ -163,6 +163,11 @@ public class TypeChecker {
             pu.analyseFlow();
         }
 
+        //check usage of private attributes/methods
+        for (PhasedUnit pu: listOfUnits) {
+            pu.analyseUsages();
+        }
+
         if (!forceSilence) {
             for (PhasedUnit pu : listOfUnits) {
                 if (verbose) {
@@ -175,9 +180,9 @@ public class TypeChecker {
             	statsVisitor.print();
             assertionVisitor.print(verbose);
         }
-        
+
     }
-    
+
     public int getErrors(){
     	return assertionVisitor.getErrors();
     }
@@ -185,7 +190,7 @@ public class TypeChecker {
     public int getWarnings(){
     	return assertionVisitor.getWarnings();
     }
-    
+
     public List<Message> getMessages(){
     	return assertionVisitor.getFoundErrors();
     }

--- a/src/com/redhat/ceylon/compiler/typechecker/TypeCheckerBuilder.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/TypeCheckerBuilder.java
@@ -29,11 +29,7 @@ public class TypeCheckerBuilder {
     private List<VirtualFile> srcDirectories = new ArrayList<VirtualFile>();
     private final VFS vfs = new VFS();
     private boolean verifyDependencies = true;
-    private AssertionVisitor assertionVisitor = new AssertionVisitor() { 
-        @Override protected boolean includeWarnings() {
-            return false;
-        }
-    };
+    private AssertionVisitor assertionVisitor = new AssertionVisitor();
     private ModuleManagerFactory moduleManagerFactory;
     private RepositoryManager repositoryManager;
     private List<String> moduleFilters = new ArrayList<String>();
@@ -67,7 +63,7 @@ public class TypeCheckerBuilder {
         this.moduleFilters.addAll(moduleFilters);
         return this;
     }
-    
+
     /**
      * @deprecated this is bad and a temporary hack
      *
@@ -95,12 +91,23 @@ public class TypeCheckerBuilder {
         this.verbose = isVerbose;
         return this;
     }
-    
+
     public TypeCheckerBuilder statistics(boolean statistics) {
         this.statistics = statistics;
         return this;
     }
-    
+
+    /**
+     * Enables or disables output of warning messages.
+     *
+     * @param includeWarnings true to enable warnings false to disable.
+     * @return typecheker instance with switched option.
+     */
+    public TypeCheckerBuilder includeWarnings(boolean includeWarnings) {
+        assertionVisitor.includeWarnings(includeWarnings);
+        return this;
+    }
+
     public TypeCheckerBuilder moduleManagerFactory(ModuleManagerFactory moduleManagerFactory){
     	this.moduleManagerFactory = moduleManagerFactory;
     	return this;
@@ -109,7 +116,7 @@ public class TypeCheckerBuilder {
     public VFS getVFS(){
         return vfs;
     }
-    
+
     public TypeChecker getTypeChecker() {
         if (repositoryManager == null) {
             repositoryManager = new RepositoryManagerBuilder( new LeakingLogger() ).buildRepository();

--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
@@ -47,12 +47,12 @@ import com.redhat.ceylon.compiler.typechecker.tree.Visitor;
  * we know is the name of the declaration and what
  * kind of declaration it is. The model objects do not
  * contain type information.
- * 
+ *
  * @author Gavin King
  *
  */
 public class DeclarationVisitor extends Visitor {
-    
+
     private final Package pkg;
     private final String filename;
     private Scope scope;
@@ -69,7 +69,7 @@ public class DeclarationVisitor extends Visitor {
     public Unit getCompilationUnit() {
         return unit;
     }
-    
+
     private Scope enterScope(Scope innerScope) {
         Scope outerScope = scope;
         scope = innerScope;
@@ -79,7 +79,7 @@ public class DeclarationVisitor extends Visitor {
     private void exitScope(Scope outerScope) {
         scope = outerScope;
     }
-    
+
     private Declaration beginDeclaration(Declaration innerDec) {
         Declaration outerDec = declaration;
         declaration = innerDec;
@@ -89,11 +89,11 @@ public class DeclarationVisitor extends Visitor {
     private void endDeclaration(Declaration outerDec) {
         declaration = outerDec;
     }
-    
+
     private void visitDeclaration(Tree.Declaration that, Declaration model) {
         visitDeclaration(that,  model, true);
     }
-    
+
     private void visitDeclaration(Tree.Declaration that, Declaration model, boolean checkDupe) {
         visitElement(that, model);
         if ( setModelName(that, model, that.getIdentifier()) ) {
@@ -105,7 +105,7 @@ public class DeclarationVisitor extends Visitor {
             scope.getMembers().add(model);
         }
 
-        handleDeclarationAnnotations(that, model);        
+        handleDeclarationAnnotations(that, model);
 
         setVisibleScope(model);
 
@@ -143,14 +143,14 @@ public class DeclarationVisitor extends Visitor {
     /*private String internalName(Node that, Declaration model,
             Tree.Identifier id) {
         String n = id.getText();
-        if ((that instanceof Tree.ObjectDefinition||that instanceof Tree.ObjectArgument) 
+        if ((that instanceof Tree.ObjectDefinition||that instanceof Tree.ObjectArgument)
                 && model instanceof Class) {
             n = "#" + n;
         }
         return n;
     }*/
 
-    private static void checkForDuplicateDeclaration(Tree.Declaration that, 
+    private static void checkForDuplicateDeclaration(Tree.Declaration that,
             final Declaration model) {
         if (model.getName()!=null) {
             if (model instanceof Setter) {
@@ -195,14 +195,14 @@ public class DeclarationVisitor extends Visitor {
         model.setUnit(unit);
         model.setContainer(scope);
     }
-    
+
     @Override
     public void visitAny(Node that) {
         that.setScope(scope);
         that.setUnit(unit);
         super.visitAny(that);
     }
-    
+
     @Override
     public void visit(Tree.CompilationUnit that) {
         unit = new Unit();
@@ -213,7 +213,7 @@ public class DeclarationVisitor extends Visitor {
         pkg.addUnit(unit);
         super.visit(that);
     }
-    
+
     @Override
     public void visit(Tree.ImportMemberOrTypeList that) {
         ImportList il = new ImportList();
@@ -224,13 +224,13 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         exitScope(o);
     }
-    
+
     @Override
     public void visit(Tree.TypeParameterList that) {
         super.visit(that);
         ((Generic) declaration).setTypeParameters(getTypeParameters(that));
-    }    
-    
+    }
+
     @Override
     public void visit(Tree.TypeDeclaration that) {
         super.visit(that);
@@ -243,7 +243,7 @@ public class DeclarationVisitor extends Visitor {
             }
         }
     }
-    
+
     @Override
     public void visit(Tree.AnyClass that) {
         Class c = that instanceof Tree.ClassDefinition ?
@@ -254,10 +254,10 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         exitScope(o);
         if (that.getParameterList()==null) {
-            that.addError("missing parameter list in class declaration: " + 
+            that.addError("missing parameter list in class declaration: " +
                     name(that.getIdentifier()), 1000 );
         }
-        if (c.isClassOrInterfaceMember() && 
+        if (c.isClassOrInterfaceMember() &&
                 c.getContainer() instanceof TypedDeclaration) {
             that.addWarning("nested classes of inner classes are not yet supported");
         }
@@ -282,7 +282,7 @@ public class DeclarationVisitor extends Visitor {
             that.addWarning("interfaces with enumerated cases not yet supported");
         }*/
     }
-    
+
     @Override
     public void visit(Tree.InterfaceDefinition that) {
         super.visit(that);
@@ -290,7 +290,7 @@ public class DeclarationVisitor extends Visitor {
             that.addWarning("introductions are not yet supported");
         }
     }
-    
+
     @Override
     public void visit(Tree.TypeParameterDeclaration that) {
         TypeParameter p = new TypeParameter();
@@ -304,7 +304,7 @@ public class DeclarationVisitor extends Visitor {
         visitDeclaration(that, p);
         super.visit(that);
     }
-    
+
     @Override
     public void visit(Tree.SequencedTypeParameterDeclaration that) {
         TypeParameter p = new TypeParameter();
@@ -314,7 +314,7 @@ public class DeclarationVisitor extends Visitor {
         visitDeclaration(that, p);
         super.visit(that);
     }
-    
+
     @Override
     public void visit(Tree.AnyMethod that) {
         Method m = new Method();
@@ -333,8 +333,21 @@ public class DeclarationVisitor extends Visitor {
                 that.addError("sequenced type parameters for methods not yet supported");
             }
         }
+
+        collectUsage(that, m.getUsages());
     }
-    
+
+    private void collectUsage(Node node, List<String> identifiers) {
+        List<Node> children = node.getChildren();
+        for (Node n : children) {
+            if (n instanceof Tree.Identifier) {
+                identifiers.add(n.getText());
+            } else {
+                collectUsage(n, identifiers);
+            }
+        }
+    }
+
     @Override
     public void visit(Tree.AnyAttribute that) {
         super.visit(that);
@@ -372,7 +385,7 @@ public class DeclarationVisitor extends Visitor {
 
     private static void checkMethodParameters(Tree.AnyMethod that) {
         if (that.getParameterLists().isEmpty()) {
-            that.addError("missing parameter list in method declaration: " + 
+            that.addError("missing parameter list in method declaration: " +
                     name(that.getIdentifier()), 1000 );
         }
         /*if ( that.getParameterLists().size()>1 ) {
@@ -391,7 +404,7 @@ public class DeclarationVisitor extends Visitor {
 
     private static void checkMethodArgumentParameters(Tree.MethodArgument that) {
         if (that.getParameterLists().isEmpty()) {
-            that.addError("missing parameter list in named argument declaration: " + 
+            that.addError("missing parameter list in named argument declaration: " +
                     name(that.getIdentifier()) );
         }
         /*if ( that.getParameterLists().size()>1 ) {
@@ -436,7 +449,7 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         exitScope(o);
     }
-    
+
     @Override
     public void visit(Tree.AttributeDeclaration that) {
         Value v = new Value();
@@ -495,7 +508,7 @@ public class DeclarationVisitor extends Visitor {
             }
         }
     }
-            
+
     @Override
     public void visit(Tree.MethodDefinition that) {
         super.visit(that);
@@ -509,7 +522,7 @@ public class DeclarationVisitor extends Visitor {
             }
         }
     }
-            
+
     @Override
     public void visit(Tree.AttributeGetterDefinition that) {
         Getter g = new Getter();
@@ -527,7 +540,7 @@ public class DeclarationVisitor extends Visitor {
             }
         }
     }
-    
+
     @Override
     public void visit(Tree.AttributeArgument that) {
         Getter g = new Getter();
@@ -537,7 +550,7 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         exitScope(o);
     }
-    
+
     @Override
     public void visit(Tree.AttributeSetterDefinition that) {
         Setter s = new Setter();
@@ -552,7 +565,7 @@ public class DeclarationVisitor extends Visitor {
         if (!(scope instanceof Package)) {
             scope.getMembers().add(p);
         }
-        
+
         s.setParameter(p);
         super.visit(that);
         exitScope(o);
@@ -573,11 +586,11 @@ public class DeclarationVisitor extends Visitor {
                 }
                 /*if (declaration instanceof Method &&
                     !declaration.isToplevel() &&
-                    !(declaration.isClassOrInterfaceMember() && 
+                    !(declaration.isClassOrInterfaceMember() &&
                             ((Declaration) declaration.getContainer()).isToplevel())) {
                     se.addWarning("default arguments for parameters of inner methods not yet supported");
                 }
-                if (declaration instanceof Class && 
+                if (declaration instanceof Class &&
                         !declaration.isToplevel()) {
                     se.addWarning("default arguments for parameters of inner classes not yet supported");
                 }*/
@@ -587,7 +600,7 @@ public class DeclarationVisitor extends Visitor {
             }
         }
     }
-    
+
     @Override
     public void visit(Tree.ValueParameterDeclaration that) {
         ValueParameter p = new ValueParameter();
@@ -629,7 +642,7 @@ public class DeclarationVisitor extends Visitor {
             f.addParameterList(parameterList);
         }
         parameterList = pl;
-        
+
         boolean foundSequenced = false;
         boolean foundDefault = false;
         for (Tree.Parameter p: that.getParameters()) {
@@ -660,9 +673,9 @@ public class DeclarationVisitor extends Visitor {
             }
         }
     }
-    
+
     private int id=0;
-    
+
     @Override
     public void visit(Tree.ControlClause that) {
         ControlBlock cb = new ControlBlock();
@@ -673,7 +686,7 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         exitScope(o);
     }
-    
+
     @Override
     public void visit(Tree.Body that) {
         int oid=id;
@@ -681,7 +694,7 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         id=oid;
     }
-    
+
     @Override
     public void visit(Tree.NamedArgumentList that) {
         NamedArgumentList nal = new NamedArgumentList();
@@ -696,7 +709,7 @@ public class DeclarationVisitor extends Visitor {
         super.visit(that);
         exitScope(o);
     }
-    
+
     @Override
     public void visit(Tree.Variable that) {
         if (that.getSpecifierExpression()!=null) {
@@ -732,7 +745,7 @@ public class DeclarationVisitor extends Visitor {
         that.setScope(scope);
         that.setUnit(unit);
     }
-    
+
     private static List<TypeParameter> getTypeParameters(Tree.TypeParameterList tpl) {
         List<TypeParameter> typeParameters = new ArrayList<TypeParameter>();
         if (tpl!=null) {
@@ -746,7 +759,7 @@ public class DeclarationVisitor extends Visitor {
         }
         return typeParameters;
     }
-    
+
     @Override public void visit(Tree.Declaration that) {
         Declaration model = that.getDeclarationModel();
         Declaration d = beginDeclaration(model);
@@ -820,8 +833,8 @@ public class DeclarationVisitor extends Visitor {
                 that.addError("declaration is not a value, and may not be annotated variable", 1500);
             }
         }
-        
-        buildAnnotations(al, model.getAnnotations());        
+
+        buildAnnotations(al, model.getAnnotations());
     }
 
     static void setVisibleScope(Declaration model) {
@@ -853,13 +866,13 @@ public class DeclarationVisitor extends Visitor {
             else {
                 model.setVisibleScope(s);
                 break;
-            }    
+            }
             s = s.getContainer();
         }
     }
 
     private static void checkFormalMember(Tree.Declaration that, Declaration d) {
-        
+
         if ( d.isFormal() ) {
             if ( !(d.getContainer() instanceof ClassOrInterface) ) {
                 that.addError("formal member does not belong to an interface or abstract class", 1100);
@@ -868,22 +881,22 @@ public class DeclarationVisitor extends Visitor {
                 that.addError("formal member belongs to a concrete class", 900);
             }
         }
-        
-        if ( d.isFormal() && 
-                !(that instanceof Tree.AttributeDeclaration) && 
+
+        if ( d.isFormal() &&
+                !(that instanceof Tree.AttributeDeclaration) &&
                 !(that instanceof Tree.MethodDeclaration) &&
                 !(that instanceof Tree.ClassDefinition)) {
             that.addError("formal member may not have a body", 1100);
         }
-        
-        /*if ( !d.isFormal() && 
-                d.getContainer() instanceof Interface && 
+
+        /*if ( !d.isFormal() &&
+                d.getContainer() instanceof Interface &&
                 !(that instanceof Tree.TypeParameterDeclaration) &&
                 !(that instanceof Tree.ClassDeclaration) &&
                 !(that instanceof Tree.InterfaceDeclaration)) {
             that.addWarning("concrete members of interfaces not yet supported");
         }*/
-        
+
     }
 
     private static void buildAnnotations(Tree.AnnotationList al, List<Annotation> annotations) {
@@ -906,7 +919,7 @@ public class DeclarationVisitor extends Visitor {
                                     ann.addNamedArgument( param, ( (Tree.BaseMemberOrTypeExpression) t ).getIdentifier().getText() );
                                 }
                             }
-                        }                    
+                        }
                     }
                 }
                 if (a.getPositionalArgumentList()!=null) {
@@ -924,7 +937,7 @@ public class DeclarationVisitor extends Visitor {
             }
         }
     }
-        
+
     @Override public void visit(Tree.TypedArgument that) {
         Declaration d = beginDeclaration(that.getDeclarationModel());
         super.visit(that);
@@ -937,14 +950,14 @@ public class DeclarationVisitor extends Visitor {
         TypeParameter p = (TypeParameter) scope.getMemberOrParameter(unit, name(that.getIdentifier()), null);
         that.setDeclarationModel(p);
         if (p==null) {
-            that.addError("no matching type parameter for constraint: " + 
+            that.addError("no matching type parameter for constraint: " +
                     name(that.getIdentifier()));
             p = new TypeParameter();
             p.setDeclaration(declaration);
             that.setDeclarationModel(p);
             visitDeclaration(that, p);
         }
-        
+
         Scope o = enterScope(p);
         super.visit(that);
         exitScope(o);
@@ -959,7 +972,7 @@ public class DeclarationVisitor extends Visitor {
             that.addWarning("parameter bounds are not yet supported");
         }
     }
-    
+
     @Override
     public void visit(Tree.SatisfiesCondition that) {
         super.visit(that);

--- a/src/com/redhat/ceylon/compiler/typechecker/context/PhasedUnit.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/context/PhasedUnit.java
@@ -33,6 +33,7 @@ import com.redhat.ceylon.compiler.typechecker.tree.Validator;
 import com.redhat.ceylon.compiler.typechecker.util.AssertionVisitor;
 import com.redhat.ceylon.compiler.typechecker.util.PrintVisitor;
 import com.redhat.ceylon.compiler.typechecker.util.StatisticsVisitor;
+import com.redhat.ceylon.compiler.typechecker.util.UsageVisitor;
 
 /**
  * Represent a unit and each of the type checking phases
@@ -63,7 +64,7 @@ public class PhasedUnit {
         return srcDir;
     }
 
-    public PhasedUnit(VirtualFile unitFile, VirtualFile srcDir, Tree.CompilationUnit cu, 
+    public PhasedUnit(VirtualFile unitFile, VirtualFile srcDir, Tree.CompilationUnit cu,
             Package p, ModuleManager moduleManager, Context context, List<CommonToken> tokenStream) {
         this.compilationUnit = cu;
         this.pkg = p;
@@ -103,11 +104,11 @@ public class PhasedUnit {
     }
 
     @Deprecated
-    protected PhasedUnit(VirtualFile unitFile, VirtualFile srcDir, Tree.CompilationUnit cu, 
+    protected PhasedUnit(VirtualFile unitFile, VirtualFile srcDir, Tree.CompilationUnit cu,
             Package p, ModuleManager moduleManager, Context context) {
         this(unitFile, srcDir, cu, p, moduleManager, context, null);
     }
-    
+
     public Module visitSrcModulePhase() {
         if ( ModuleManager.MODULE_FILE.equals(fileName) ||
                 ModuleManager.PACKAGE_FILE.equals(fileName) ) {
@@ -124,7 +125,7 @@ public class PhasedUnit {
             compilationUnit.visit(moduleVisitor);
         }
     }
-    
+
     public boolean isFullyTyped() {
         return fullyTyped;
     }
@@ -132,7 +133,7 @@ public class PhasedUnit {
     public void setFullyTyped(boolean fullyTyped) {
         this.fullyTyped = fullyTyped;
     }
-    
+
     public boolean isFlowAnalyzed() {
         return flowAnalyzed;
     }
@@ -219,11 +220,15 @@ public class PhasedUnit {
         }
     }
 
+    public void analyseUsages() {
+        compilationUnit.visit(new UsageVisitor());
+    }
+
     public void collectUnitDependencies(PhasedUnits phasedUnits, List<PhasedUnits> phasedUnitsOfDependencies) {
         //System.out.println("Run collecting unit dependencies phase for " + fileName);
         compilationUnit.visit(new DependedUponVisitor(this, phasedUnits, phasedUnitsOfDependencies));
     }
-    
+
     public synchronized void analyseFlow() {
         if (! flowAnalyzed) {
             //System.out.println("Validate control flow for " + fileName);
@@ -246,7 +251,7 @@ public class PhasedUnit {
     public void generateStatistics(StatisticsVisitor statsVisitor) {
         compilationUnit.visit(statsVisitor);
     }
-    
+
     public void runAssertions(AssertionVisitor av) {
         //System.out.println("Running assertions for " + fileName);
         compilationUnit.visit(av);
@@ -256,11 +261,11 @@ public class PhasedUnit {
         System.out.println("Displaying " + fileName);
         compilationUnit.visit(new PrintVisitor());
     }
-    
+
     public Package getPackage() {
         return pkg;
     }
-    
+
     public Unit getUnit() {
         return unit;
     }

--- a/src/com/redhat/ceylon/compiler/typechecker/model/Method.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/model/Method.java
@@ -24,6 +24,9 @@ public class Method extends MethodOrValue implements Generic, Scope, Functional 
     private List<Declaration> overloads;
     private boolean declaredVoid;
 
+    //list of identifiers declared somewhere and used inside this method
+    private List<String> usages = new ArrayList();
+
     /*public boolean isFormal() {
          return formal;
      }
@@ -31,7 +34,7 @@ public class Method extends MethodOrValue implements Generic, Scope, Functional 
      public void setFormal(boolean formal) {
          this.formal = formal;
      }*/
-    
+
     @Override
     public boolean isParameterized() {
         return !typeParameters.isEmpty();
@@ -59,38 +62,38 @@ public class Method extends MethodOrValue implements Generic, Scope, Functional 
     public boolean isOverloaded() {
     	return overloaded;
     }
-    
+
     public void setOverloaded(boolean overloaded) {
 		this.overloaded = overloaded;
 	}
-    
+
     public void setAbstraction(boolean abstraction) {
         this.abstraction = abstraction;
     }
-    
+
     @Override
     public boolean isAbstraction() {
         return abstraction;
     }
-    
+
     @Override
     public boolean isDeclaredVoid() {
         return declaredVoid;
     }
-    
+
     public void setDeclaredVoid(boolean declaredVoid) {
         this.declaredVoid = declaredVoid;
     }
-    
+
     @Override
     public List<Declaration> getOverloads() {
         return overloads;
     }
-    
+
     public void setOverloads(List<Declaration> overloads) {
         this.overloads = overloads;
     }
-    
+
     public Parameter getParameter(String name) {
         for (Declaration d : getMembers()) {
             if (isParameter(d) && isNamed(name, d)) {
@@ -99,5 +102,23 @@ public class Method extends MethodOrValue implements Generic, Scope, Functional 
         }
         return null;
     }
-    
+
+/**
+     * Gets the list of identifiers used inside this method.
+     *
+     * @return list of identifiers.
+     */
+    public List<String> getUsages() {
+        return usages;
+    }
+
+    /**
+     * Checks usage of the given identifier.
+     *
+     * @param identifier the identifier to check.
+     * @return true if the given identifier is used inside method and false otherwise.
+     */
+    public boolean isUsed(String identifier) {
+        return usages.contains(identifier);
+    }
 }

--- a/src/com/redhat/ceylon/compiler/typechecker/util/AssertionVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/util/AssertionVisitor.java
@@ -17,11 +17,14 @@ import com.redhat.ceylon.compiler.typechecker.tree.UnexpectedError;
 import com.redhat.ceylon.compiler.typechecker.tree.Visitor;
 
 public class AssertionVisitor extends Visitor implements NaturalVisitor {
-    
+
     private boolean expectingError = false;
     private List<Message> foundErrors = new ArrayList<Message>();
     private int errors = 0;
     private int warnings = 0;
+
+    //output warnings or not
+    private boolean includeWarnings = false;
 
     @Override
     public void visit(Tree.TypedDeclaration that) {
@@ -36,12 +39,12 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
         checkType(that, that.getExpression().getTypeModel(), that.getExpression());
         super.visit(that);
     }
-    
+
     private void checkType(Tree.Statement that, ProducedType type, Node typedNode) {
         for (Tree.CompilerAnnotation c: that.getCompilerAnnotations()) {
             if (c.getIdentifier().getText().equals("type")) {
                 String expectedType = c.getStringLiteral().getText();
-                if (typedNode==null || type==null || 
+                if (typedNode==null || type==null ||
                         type.getDeclaration()==null) {
                     out(that, "type not known");
                 }
@@ -53,7 +56,7 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
             }
         }
     }
-    
+
     @Override
     public void visit(Tree.StatementOrArgument that) {
         if (that instanceof Tree.Variable) {
@@ -72,7 +75,7 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
         expectingError = b;
         foundErrors = f;
     }
-    
+
     @Override
     public void visit(Tree.CompilationUnit that) {
     	expectingError = false;
@@ -84,7 +87,7 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
     	expectingError = false;
     	super.visitAny(that);
     }
-    
+
     @Override
     public void visit(Tree.Declaration that) {
         super.visit(that);
@@ -106,7 +109,7 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
 
     protected void out(Node that, String message) {
         System.err.println(
-            message + " at " + 
+            message + " at " +
             that.getLocation() + " of " +
             that.getUnit().getFilename());
     }
@@ -115,8 +118,8 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
         errors++;
         System.err.println(
             "lex error encountered [" +
-            err.getMessage() + "] at " + 
-            err.getHeader() + " of " + 
+            err.getMessage() + "] at " +
+            err.getHeader() + " of " +
             that.getUnit().getFilename());
     }
 
@@ -124,8 +127,8 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
         errors++;
         System.err.println(
             "parse error encountered [" +
-            err.getMessage() + "] at " + 
-            err.getHeader() + " of " + 
+            err.getMessage() + "] at " +
+            err.getHeader() + " of " +
             that.getUnit().getFilename());
     }
 
@@ -133,7 +136,7 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
         errors++;
         System.err.println(
             "unexpected error encountered [" +
-            err.getMessage() + "] at " + 
+            err.getMessage() + "] at " +
             err.getTreeNode().getLocation() + " of " +
             err.getTreeNode().getUnit().getFilename());
     }
@@ -142,7 +145,7 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
         errors++;
         System.err.println(
             "error encountered [" +
-            err.getMessage() + "] at " + 
+            err.getMessage() + "] at " +
             err.getTreeNode().getLocation() + " of " +
             err.getTreeNode().getUnit().getFilename());
     }
@@ -151,7 +154,7 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
         warnings++;
         System.out.println(
             "warning encountered [" +
-            err.getMessage() + "] at " + 
+            err.getMessage() + "] at " +
             err.getTreeNode().getLocation() + " of " +
             err.getTreeNode().getUnit().getFilename());
     }
@@ -184,14 +187,14 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
                     out( (AnalysisError) err );
                 }
                 else if (err instanceof AnalysisWarning) {
-                    if (includeWarnings()) {
+                    if (includeWarnings) {
                         out( (AnalysisWarning) err );
                     }
                 }
             }
         }
     }
-    
+
     protected void initExpectingError(List<Tree.CompilerAnnotation> annotations) {
         for (Tree.CompilerAnnotation c: annotations) {
             if (c.getIdentifier().getText().equals("error")) {
@@ -199,17 +202,17 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
             }
         }
     }
-    
-    protected boolean includeWarnings() {
-        return true;
+
+    public void includeWarnings(boolean includeWarnings) {
+        this.includeWarnings = includeWarnings;
     }
-    
+
     @Override
     public void visitAny(Node that) {
         foundErrors.addAll(that.getErrors());
         super.visitAny(that);
     }
-    
+
     public void print(boolean verbose) {
     	if(!verbose && errors == 0 && warnings == 0)
     		return;
@@ -227,5 +230,5 @@ public class AssertionVisitor extends Visitor implements NaturalVisitor {
 	public int getWarnings() {
 		return warnings;
 	}
-    
+
 }

--- a/src/com/redhat/ceylon/compiler/typechecker/util/UsageVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/util/UsageVisitor.java
@@ -1,0 +1,73 @@
+
+package com.redhat.ceylon.compiler.typechecker.util;
+
+import com.redhat.ceylon.compiler.typechecker.model.Declaration;
+import com.redhat.ceylon.compiler.typechecker.model.Method;
+import com.redhat.ceylon.compiler.typechecker.model.Value;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree;
+import com.redhat.ceylon.compiler.typechecker.tree.Visitor;
+import java.util.List;
+
+/**
+ * Performs analysis of the usage of private attributes and methods.
+ *
+ * @author kulikov
+ */
+public class UsageVisitor extends Visitor {
+@Override
+    public void visit(Tree.AnyAttribute attribute) {
+        super.visit(attribute);
+
+        //Do not check usage of the shared attribute
+        if (attribute.getDeclarationModel().isShared()) {
+            return;
+        }
+
+        String name = attribute.getDeclarationModel().getName();
+        Value v = (Value) attribute.getDeclarationModel();
+
+        if (v.getContainer() instanceof com.redhat.ceylon.compiler.typechecker.model.Class) {
+            if (!isUsed((com.redhat.ceylon.compiler.typechecker.model.Class)v.getContainer(), name)) {
+                attribute.addWarning(String.format("Attribute %s declared but never used", name));
+            }
+        } else if (v.getContainer() instanceof Method) {
+            if (!isUsed((Method)v.getContainer(), name)) {
+                attribute.addWarning(String.format("Attribute %s declared but never used", name));
+            }
+        }
+    }
+
+    @Override
+    public void visit(Tree.AnyMethod method) {
+        super.visit(method);
+
+        //do not check method usage if it is shared
+        if (method.getDeclarationModel().isShared()) {
+            return;
+        }
+
+        String name = method.getDeclarationModel().getName();
+        if (!isUsed((com.redhat.ceylon.compiler.typechecker.model.Class)method.getDeclarationModel().getContainer(), name)) {
+            method.addWarning(String.format("Method %s declared but never used", name));
+        }
+
+    }
+
+    private boolean isUsed(com.redhat.ceylon.compiler.typechecker.model.Class cls, String identifier) {
+        List<Declaration> members = cls.getMembers();
+
+        for (Declaration d : members) {
+            if (d instanceof Method) {
+                if (isUsed((Method)d, identifier)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isUsed(Method method, String identifier) {
+        return method.isUsed(identifier);
+    }
+}


### PR DESCRIPTION
Added analysis of usage of private methods and attributes. Warning message is generated if attribute/method declared but never used.

AssertionVistor: added configurable option for enabling/disabling warnings.
TypechekerBuilder: added option for enabling/disabling warnings instead of method override.
