### PR TITLE
Make the TypeCheckerBuilder use a properly configured RepositoryManager

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/TypeCheckerBuilder.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/TypeCheckerBuilder.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.redhat.ceylon.cmr.api.RepositoryManager;
-import com.redhat.ceylon.cmr.api.RepositoryManagerBuilder;
+import com.redhat.ceylon.cmr.ceylon.CeylonUtils;
 import com.redhat.ceylon.compiler.typechecker.io.VFS;
 import com.redhat.ceylon.compiler.typechecker.io.VirtualFile;
 import com.redhat.ceylon.compiler.typechecker.io.cmr.impl.LeakingLogger;
@@ -123,7 +123,7 @@ public class TypeCheckerBuilder {
     
     public TypeChecker getTypeChecker() {
         if (repositoryManager == null) {
-            repositoryManager = new RepositoryManagerBuilder( new LeakingLogger() ).buildRepository();
+            repositoryManager = CeylonUtils.makeRepositoryManager(null, null, new LeakingLogger());
         }
         return new TypeChecker(vfs, srcDirectories, repositoryManager, verifyDependencies, assertionVisitor, moduleManagerFactory, verbose, statistics, moduleFilters);
     }


### PR DESCRIPTION
This makes sure that the TypeCheckerBuilder uses a RepositoryBuilder that adheres to the Ceylon definition for default repositories and knows how to handle overrides in configuration files etc.
The default RepositoryBuilder would only look in the user repository which worked before (as long as you had everything published correctly) but now it doesn't anymore because the default folder has been changed to the cache folder (~/.ceylon/cache) which doesn't (shouldn't) contain any of the required system modules.
