### PR TITLE
Add module information required by annotations

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/model/InlineInfo.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/model/InlineInfo.java
@@ -1,0 +1,67 @@
+package com.redhat.ceylon.compiler.typechecker.model;
+
+import java.util.List;
+
+import com.redhat.ceylon.compiler.typechecker.model.Declaration;
+import com.redhat.ceylon.compiler.typechecker.model.Parameter;
+
+public class InlineInfo {
+
+    private Declaration primary;
+    private List<InlineArgument> arguments;
+    
+    public abstract class InlineArgument {
+        Parameter targetParameter;
+
+        public Parameter getTargetParameter() {
+            return targetParameter;
+        }
+
+        public void setTargetParameter(Parameter parameter) {
+            this.targetParameter = parameter;
+        }
+        
+    }
+    
+    public class ParameterArgument extends InlineArgument {
+        private Parameter sourceParameter;
+        private boolean spread;
+
+        public Parameter getSourceParameter() {
+            return sourceParameter;
+        }
+
+        public void setSourceParameter(Parameter sourceParameter) {
+            this.sourceParameter = sourceParameter;
+        }
+
+        public boolean isSpread() {
+            return spread;
+        }
+
+        public void setSpread(boolean spread) {
+            this.spread = spread;
+        }
+    }
+    
+    
+    public class LiteralArgument extends InlineArgument {
+    }
+
+    public Declaration getPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(Declaration primary) {
+        this.primary = primary;
+    }
+
+    public List<InlineArgument> getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(List<InlineArgument> arguments) {
+        this.arguments = arguments;
+    }
+    
+}

--- a/src/com/redhat/ceylon/compiler/typechecker/model/Method.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/model/Method.java
@@ -23,6 +23,8 @@ public class Method extends MethodOrValue implements Generic, Scope, Functional 
     private boolean abstraction;
     private List<Declaration> overloads;
     private boolean declaredAnything;
+    private InlineInfo inlineInfo;
+    
 
     /*public boolean isFormal() {
          return formal;
@@ -32,6 +34,15 @@ public class Method extends MethodOrValue implements Generic, Scope, Functional 
          this.formal = formal;
      }*/
     
+
+    public InlineInfo getInlineInfo() {
+        return inlineInfo;
+    }
+
+    public void setInlineInfo(InlineInfo inlineInfo) {
+        this.inlineInfo = inlineInfo;
+    }
+
     @Override
     public boolean isParameterized() {
         return !typeParameters.isEmpty();


### PR DESCRIPTION
@gavinking This is the change to `Method` I was talking about in ceylon/ceylon-compiler#1092. 
