### PR TITLE
Checksum file now contains just the SHA1 value

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -400,7 +400,7 @@
         <fail if="value"/>
         <basename file="${file}" property="filename"/>
         <checksum file="${file}" property="value" algorithm="sha1"/>
-        <echo file="${file}.sha1" message="${value}${checksum.binary-prefix}${filename}"/>
+        <echo file="${file}.sha1" message="${value}"/>
     </target>
     <!-- Repository targets -->
     <target name="init.repo"


### PR DESCRIPTION
Consistent with other modules, retains only SHA1 value in checksum file in build.xml. Resolves ceylon/ceylon-module-resolver/#61
