### PR TITLE
Add VisitorAdaptorgen.g for Ceylon interoperability

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -345,6 +345,7 @@
             <!--arg value="treegen/Buildergen.g"-->
             <arg value="treegen/Walkergen.g"/>
             <arg value="treegen/Visitorgen.g"/>
+            <arg value="treegen/VisitorAdaptorgen.g"/>
             <arg value="treegen/Validatorgen.g"/>
             <classpath>
                 <pathelement location="${antlr.lib}"/>

--- a/src/com/redhat/ceylon/compiler/typechecker/treegen/Generate.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/treegen/Generate.java
@@ -70,6 +70,18 @@ public class Generate {
         parser.nodeList();
     }
     
+    private static void visitorAdaptor(File file) throws Exception {
+        InputStream is = new FileInputStream( file );
+        ANTLRInputStream input = new ANTLRInputStream(is);
+        VisitorAdaptorgenLexer lexer = new VisitorAdaptorgenLexer(input);
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        VisitorAdaptorgenParser parser = new VisitorAdaptorgenParser(tokens);
+        File out = new File( GENERATED_PACKAGE_DIR + "VisitorAdaptor.java" );
+        out.createNewFile();
+        Util.out=new PrintStream(out);
+        parser.nodeList();
+    }
+    
     private static void validator(File file) throws Exception {
         InputStream is = new FileInputStream( file );
         ANTLRInputStream input = new ANTLRInputStream(is);

--- a/treegen/VisitorAdaptorgen.g
+++ b/treegen/VisitorAdaptorgen.g
@@ -1,0 +1,67 @@
+grammar VisitorAdaptorgen;
+
+@parser::header { 
+    package com.redhat.ceylon.compiler.typechecker.treegen; 
+    import static com.redhat.ceylon.compiler.typechecker.treegen.Util.*; 
+}
+@lexer::header { 
+    package com.redhat.ceylon.compiler.typechecker.treegen; 
+}
+
+nodeList : { 
+           println("package com.redhat.ceylon.compiler.typechecker.tree;\n");
+           println("import static com.redhat.ceylon.compiler.typechecker.tree.Tree.*;");
+           println("import static com.redhat.ceylon.compiler.typechecker.tree.Tree.Package;\n");
+           println("public abstract class VisitorAdaptor extends Visitor {\n");
+           println("    public void handleException(Exception e, Node that) { that.handleException(e, this); }\n");
+           println("    public void visitAny(Node that) { that.visitChildren(this); }\n");
+           }
+           (DESCRIPTION? node)+ 
+           EOF
+           { println("\n}"); }
+           ;
+
+node : '^' '('
+       'abstract'? n=NODE_NAME
+       (
+         {
+           println("    public void visit" + className($n.text) + "(" + className($n.text) + " that) { visitAny(that); }");
+           println("    @Override public final void visit(" + className($n.text) + " that) { visit" + className($n.text) + "(that); }");
+         }
+       | ':' en=NODE_NAME
+         {
+           println("    public void visit" + className($n.text) + "(" + className($n.text) + " that) { visit" + className($en.text) + "(that); }");
+           println("    @Override public final void visit(" + className($n.text) + " that) { visit" + className($n.text) + "(that); }");
+         }
+       ) 
+       (DESCRIPTION? subnode)*
+       (DESCRIPTION? field)*
+       ')'
+     ;
+
+subnode : n=NODE_NAME '?'? f=FIELD_NAME? 
+        | mn=NODE_NAME '*' f=FIELD_NAME?
+        ;
+
+field : 'abstract'? (TYPE_NAME|'boolean') FIELD_NAME ';';
+
+NODE_NAME : ('A'..'Z'|'_')+;
+
+FIELD_NAME : ('a'..'z') ('a'..'z'|'A'..'Z')*;
+TYPE_NAME : ('A'..'Z') ('a'..'z'|'A'..'Z'|'<'|'>')*;
+
+WS : (' ' | '\n' | '\t' | '\r' | '\u000C') { skip(); };
+
+CARAT : '^';
+
+LPAREN : '(';
+RPAREN : ')';
+
+MANY : '*'|'+';
+OPTIONAL : '?';
+
+EXTENDS : ':';
+
+SEMI : ';';
+
+DESCRIPTION : '\"' (~'\"')* '\"';


### PR DESCRIPTION
This adds a VisitorAdaptorgen grammar that will in turn generate a VisitorAdaptor class which extends Visitor, but offers distinct method names for each Node type
(since Visitor's `visit(AnyOfAThousandSubtypes that)` can't be used from Ceylon).

CC [ceylon-ide-eclipse#385](https://github.com/ceylon/ceylon-ide-eclipse/issues/385)
