### PR TITLE
Necessary change to solve https://github.com/ceylon/ceylon-ide-eclipse/issues/761

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/ModuleManager.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/ModuleManager.java
@@ -50,7 +50,7 @@ public class ModuleManager {
     
     protected Package createPackage(String pkgName, Module module) {
         final Package pkg = new Package();
-        List<String> name = pkgName.isEmpty() ? Collections.<String>emptyList() : splitModuleName(pkgName); 
+        List<String> name = pkgName.isEmpty() ? Arrays.asList("") : splitModuleName(pkgName); 
         pkg.setName(name);
         if (module != null) {
             module.getPackages().add(pkg);

--- a/src/com/redhat/ceylon/compiler/typechecker/model/Util.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/model/Util.java
@@ -650,15 +650,22 @@ public class Util {
         return false;
     }
     
-    public static String formatPath(List<String> path) {
+    public static String formatPath(List<String> path, char separator) {
         StringBuilder sb = new StringBuilder();
         for (int i=0; i<path.size(); i++) {
-            sb.append(path.get(i));
-            if (i<path.size()-1) sb.append('.');
+            String pathPart = path.get(i);
+            if (! pathPart.isEmpty()) {
+                sb.append(pathPart);
+                if (i<path.size()-1) sb.append(separator);
+            }
         }
         return sb.toString();
     }
 
+    public static String formatPath(List<String> path) {
+        return formatPath(path, '.');
+    }
+    
     static boolean addToSupertypes(List<ProducedType> list, ProducedType st) {
         for (ProducedType et: list) {
             if (st.getDeclaration().equals(et.getDeclaration()) && //return both a type and its self type


### PR DESCRIPTION
Change the name of the default package to a list with one empty string (instead of a void list of string). This is needed to be consistent with
the way the Java backend manages it. Consistency between front-end and
backend here is needed to allow the backend to reuse the model existing inside the IDE.

FYI : ant test on ceylon-spec were successful, as well as the compilation of the SDK within the IDE with this change.
