### PR TITLE
Attmpt to fix https://github.com/ceylon/ceylon-compiler/issues/1475

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/TypeHierarchyVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/TypeHierarchyVisitor.java
@@ -1,6 +1,7 @@
 package com.redhat.ceylon.compiler.typechecker.analyzer;
 
 import static com.redhat.ceylon.compiler.typechecker.model.Util.isResolvable;
+import static com.redhat.ceylon.compiler.typechecker.model.Util.isOverloadedVersion;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -421,7 +422,7 @@ public class TypeHierarchyVisitor extends Visitor {
                         !((ClassOrInterface) td).isAbstract() &&
                         !((ClassOrInterface) td).isAlias()) {
                     for (Declaration d: st.getDeclaration().getMembers()) {
-                        if (d.isShared() && isResolvable(d) && 
+                        if (d.isShared() && !isOverloadedVersion(d) && isResolvable(d) && 
                                 !errors.contains(d.getName())) {
                             Declaration r = td.getMember(d.getName(), null, false);
                             if (r==null || !r.refines(d) && 


### PR DESCRIPTION
We should not throw the error when the member obtained by `getMembers()`
is an overloaded version of a Java class constructor (since it can be shared while the corresponding abstraction declaration is not). Just skip it since
`getMembers()` also returns the corresponding abstraction declaration

It seems OK to me, and the spec tests pass, but I prefer you to confirm this is the right thing to do.
