### PR TITLE
Fix definition of TypeList in the spec

### DIFF
--- a/en/modules/typesystem.xml
+++ b/en/modules/typesystem.xml
@@ -755,7 +755,7 @@
             
             <synopsis>TupleType: "[" TypeList "]"</synopsis>
             
-            <synopsis>TypeList: (EntryType ",")* UnionType ("*"|"+")?</synopsis>
+            <synopsis>TypeList: (Type ",")* UnionType ("*"|"+")?</synopsis>
             
             <itemizedlist>
                 <listitem>


### PR DESCRIPTION
The previous definition

```
TypeList: (EntryType ",")* UnionType ("*"|"+")?
```

would only allow type lists like

```
X->Y, A->B, X*
```

but not

```
X, Y, A, B, X*
```

because `X`, `Y`, `A`, `B` are not `EntryType`s.

I suspect there was some confusion with the way that `UnionType` and `IntersectionType` work: A `UnionType` is `IntersectionType ("," IntersectionType)*`, so even `A` (which we wouldn’t call a Union Type) is grammar-wise a `UnionType`. The original author probably thought that `EntryType` works like this as well.
