### PR TITLE
Fix nonempty variadic parameters declared in body

### DIFF
--- a/src/com/redhat/ceylon/compiler/typechecker/analyzer/TypeVisitor.java
+++ b/src/com/redhat/ceylon/compiler/typechecker/analyzer/TypeVisitor.java
@@ -1121,7 +1121,10 @@ public class TypeVisitor extends Visitor {
         if (dec!=null && dec.isParameter() && 
                 dec.getInitializerParameter().isHidden()) {
             Parameter param = dec.getInitializerParameter();
-            param.setSequenced(that.getType() instanceof Tree.SequencedType);
+            if (that.getType() instanceof Tree.SequencedType) {
+                param.setSequenced(true);
+                param.setAtLeastOne(((Tree.SequencedType)that.getType()).getAtLeastOne());
+            }
             if (sie!=null) {
                 sie.addError("value is an initializer parameter and may not have an initial value: " + 
                         dec.getName());


### PR DESCRIPTION
For nonempty variadic parameters that were declared in the body, like this:

```
void f(elems) {
    String+ elems;
    // ...
}
```

the `TypeVisitor` forgot to carry over the `atLeastOne` information from the `SequencedType`. This blew up the Java backend (incompatible type, `Sequential` vs `Sequence`). (The JS backend didn’t care.)
