### PR TITLE
Clarify that bounded comparison evaluates x only once

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -1970,19 +1970,19 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
         <itemizedlist>
             <listitem>
                 <para><literal>l&lt;x&lt;u</literal> means 
-                <literal>x&gt;l &amp;&amp; x&lt;u</literal>,</para>
+                <literal>let t=x in t&gt;l &amp;&amp; t&lt;u</literal>,</para>
             </listitem>
             <listitem>
                 <para><literal>l&lt;=x&lt;u</literal> means 
-                <literal>x&gt;=l &amp;&amp; x&lt;u</literal>,</para>
+                <literal>let t=x in t&gt;=l &amp;&amp; t&lt;u</literal>,</para>
             </listitem>
             <listitem>
                 <para><literal>l&lt;x&lt;=u</literal> means 
-                <literal>x&gt;l &amp;&amp; x&lt;=u</literal>, and</para>
+                <literal>let t=x in t&gt;l &amp;&amp; t&lt;=u</literal>, and</para>
             </listitem>
             <listitem>
                 <para><literal>l&lt;=x&lt;=u</literal> means 
-                <literal>x&gt;=l &amp;&amp; x&lt;=u</literal></para>
+                <literal>let t=x in t&gt;=l &amp;&amp; t&lt;=u</literal></para>
             </listitem>
         </itemizedlist>
         


### PR DESCRIPTION
The old definition

```
l<x<u means x>l && x<u
```

could have been misunderstood to mean that x would be evaluated twice. Rectify this using 'let'.

@gavinking do you think this is necessary? Not sure.

(It also seems that the compiler implements `l<x<u` as `l<x && x<u`, rather than `x>l && x<u`, but I’m starting to feel like an obnoxious nit-pick pointing out these small differences, so I’m just going to forget that I saw that. No need to delay 1.1 for that.)
