### PR TITLE
Remove 'satisfies' from spec operator table

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -1569,8 +1569,8 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
                 <literal>&gt;=</literal>,
                 <literal>in</literal>,
                 <literal>is</literal>,
-                <literal>of</literal>,
-                <literal>satisfies</literal>
+                <literal>of</literal><!--,
+                <literal>satisfies</literal>-->
                 </entry>
                 <entry>Binary (and ternary)</entry>
                 <entry>None</entry>


### PR DESCRIPTION
``` ceylon
print(true satisfies Boolean?);
```

> error: `satisfies` operator not yet supported

It’s also not actually defined in any of the operator definition sections… it has no business being in the operator table!
