### PR TITLE
Remove '^=' operator from operator table

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -1636,7 +1636,7 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
                 <literal>%=</literal>, 
                 <literal>&amp;=</literal>, 
                 <literal>|=</literal>, 
-                <literal>^=</literal>, 
+                <!--<literal>^=</literal>,-->
                 <literal>~=</literal>, 
                 <literal>&amp;&amp;=</literal>, 
                 <literal>||=</literal>


### PR DESCRIPTION
There is no "power + assignment" operator. Code with `^=` doesn’t actually parse.

I’m not saying that operator _shouldn’t_ exist, but it doesn’t exist at the moment, so it has no place in the spec :)
