### PR TITLE
Remove TODO for already implemented feature

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -633,12 +633,6 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
         <literal>A</literal>, then <literal>A</literal> must be a subtype of 
         <literal>P</literal>.</para>
             
-        <comment><para>TODO: should we support an infix-operator-style syntax for method 
-        invocation like <literal>string split ",;".contains</literal>? This is especially 
-        nice for conceptually symmetric operations like <literal>a xor b</literal>, or when 
-        the argument is an anonymous function like 
-        <literal>people map (Person p)=>p.firstName+p.lastName</literal>.</para></comment>
-            
         <section id="directinvocations">
             <title>Direct invocations</title>
             


### PR DESCRIPTION
Operator-style member and invocation expressions have already been added to the language (see §6.9).
