### PR TITLE
Add missing semicolon in ParameterDeclaration BNF

### DIFF
--- a/en/modules/declarations.xml
+++ b/en/modules/declarations.xml
@@ -369,7 +369,7 @@ TypeConstraints?
         a control structure. Nor may a parameter declaration appear as a toplevel declaration 
         in a compilation unit.</para>
         
-        <synopsis>ParameterDeclaration: ValueParameter | CallableParameter | VariadicParameter</synopsis>
+        <synopsis>ParameterDeclaration: ( ValueParameter | CallableParameter | VariadicParameter ) ";"</synopsis>
         
         <para>Every parameter declaration that occurs outside a parameter list must be named
         in the parameter list of the class or function in whose body it directly occurs, and


### PR DESCRIPTION
When a parameter is declared normally, within the body of the class or function, then the declaration must be terminated by a semicolon.

(The ParameterDeclaration rule is only used in the Declaration rule.)

@gavinking does this look right to you? I’m not entirely sure that semicolon isn’t already art of the grammar somewhere else.
