### PR TITLE
Fix bug in anonymous function example

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -324,7 +324,7 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
             
             <programlisting>(String string) {
     value mid = string.size / 2;
-    return [string[0..mid],string[mid+1...]];
+    return [string[...mid],string[mid+1...]];
 }</programlisting>
             
             <para>An anonymous function occurring in an <literal>extends</literal>


### PR DESCRIPTION
The name and the rest of the function suggest that `mid` is supposed to be half the length, not the parity of the length, of the string.
