### PR TITLE
Fix method called when exiting try block

### DIFF
--- a/en/modules/execution.xml
+++ b/en/modules/execution.xml
@@ -770,7 +770,7 @@ String result = middleObject.string;</programlisting>
                  </listitem>
                  <listitem>
                      <para><literal>destroy()</literal> is called on each resource instance
-                     of type <literal>Destroyable</literal>, and <literal>obtain()</literal> 
+                     of type <literal>Destroyable</literal>, and <literal>release()</literal> 
                      is called on each resource instance of type <literal>Obtainable</literal>, 
                      if any, in the reverse order that the resource expressions occur, 
                      passing the exception that propagated out of the <literal>try</literal> 


### PR DESCRIPTION
`obtain()` is called when the block is entered; when the block is exited, `release()` is called.
