### PR TITLE
Add missing type parameter to Ranged

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -2196,33 +2196,33 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
             <entry><literal>lhs[from:length]</literal></entry>
             <entry>measured subrange</entry>
             <entry><literal>lhs.measure(from,length)</literal></entry>
-            <entry><literal>Ranged&lt;X,Y&gt;</literal></entry>
+            <entry><literal>Ranged&lt;X,Y,Z&gt;</literal></entry>
             <entry><literal>X</literal>, <literal>Integer</literal></entry>
-            <entry><literal>Y</literal></entry>
+            <entry><literal>Z</literal></entry>
         </row>
         <row>
             <entry><literal>lhs[from..to]</literal></entry>
             <entry>spanned subrange</entry>
             <entry><literal>lhs.span(from,to)</literal></entry>
-            <entry><literal>Ranged&lt;X,Y&gt;</literal></entry>
+            <entry><literal>Ranged&lt;X,Y,Z&gt;</literal></entry>
             <entry><literal>X</literal>, <literal>X</literal></entry>
-            <entry><literal>Y</literal></entry>
+            <entry><literal>Z</literal></entry>
         </row>
         <row>
             <entry><literal>lhs[from...]</literal></entry>
             <entry>upper spanned subrange</entry>
             <entry><literal>lhs.spanFrom(from)</literal></entry>
-            <entry><literal>Ranged&lt;X,Y&gt;</literal></entry>
+            <entry><literal>Ranged&lt;X,Y,Z&gt;</literal></entry>
             <entry><literal>X</literal></entry>
-            <entry><literal>Y</literal></entry>
+            <entry><literal>Z</literal></entry>
         </row>
         <row>
             <entry><literal>lhs[...to]</literal></entry>
             <entry>lower spanned subrange</entry>
             <entry><literal>lhs.spanTo(to)</literal></entry>
-            <entry><literal>Ranged&lt;X,Y&gt;</literal></entry>
+            <entry><literal>Ranged&lt;X,Y,Z&gt;</literal></entry>
             <entry><literal>X</literal></entry>
-            <entry><literal>Y</literal></entry>
+            <entry><literal>Z</literal></entry>
         </row>
         
         <row><entry namest="first" nameend="last"><emphasis>Spread invocation</emphasis></entry></row>


### PR DESCRIPTION
`Ranged` has three type parameters: `Index`, `Element`, and `Subrange`. The specification table for subrange operators was missing the second one.
