### PR TITLE
syntax highlighter: recognize "shebang" comments

### DIFF
--- a/en/styles/ceylon.js
+++ b/en/styles/ceylon.js
@@ -35,7 +35,7 @@ Rainbow.extend( "ceylon", [
   },
   {
     name: "comment",
-    pattern: /\/\*[\s\S]*?\*\/|(\/\/).*?$/gm
+    pattern: /\/\*[\s\S]*?\*\/|(\/\/).*?$|(\#\!).*?$/gm
   },
   {
     name: "entity.function",


### PR DESCRIPTION
See 2.2, "Comments", for an example.
