### PR TITLE
Fix NullPointerException when parsing incomplete if expression

### DIFF
--- a/Ceylon.g
+++ b/Ceylon.g
@@ -2064,7 +2064,7 @@ ifExpression returns [IfExpression term]
       thenElseClauses
       { $term.setIfClause($thenElseClauses.ifClause);
         $term.setElseClause($thenElseClauses.elseClause);
-        if ($thenElseClauses.ifClause==null && $thenElseClauses.conditionList!=null) 
+        if ($thenElseClauses.ifClause==null)
             $term.setIfClause(new IfClause(null));
         $term.getIfClause().setConditionList($thenElseClauses.conditionList); }
     ;


### PR DESCRIPTION
The grammar checks if the thenElseClauses rule returned conditions, but not an if clause to attach them to; if that is the case, a fake if clause is created so the conditions can be attached to it. The grammar then used to proceed to unconditionally attach the conditions to the if clause.

In the event that the thenElseClauses rule returned neither an if clause nor conditions – as in the following code

``` ceylon
Anything a = if;
```

– the grammar would still attempt to attach the null conditions to the null if clause, resulting in an NPE.

Easily fixed by creating the fake if clause regardless of whether there are conditions to attach or not.
