### PR TITLE
Fix ClassBody BNF rule

### DIFF
--- a/en/modules/declarations.xml
+++ b/en/modules/declarations.xml
@@ -1031,7 +1031,7 @@ TypeConstraints?
             </listitem>
         </itemizedlist>
 
-        <synopsis>ClassBody: "{" (Declaration | Statement | Constructor)* "}"</synopsis>
+        <synopsis>ClassBody: "{" (Declaration | Statement | ConstructorDeclaration)* "}"</synopsis>
         
         <para>The body of a class may contain executable code.</para>
         


### PR DESCRIPTION
The rule for constructors in section 4.9 is called `ConstructorDeclaration`, not just `Constructor`.

CC @gavinking.