### PR TITLE
Fix tuplePatternStart rule for [*foo] patterns

### DIFF
--- a/Ceylon.g
+++ b/Ceylon.g
@@ -451,7 +451,7 @@ setterDeclaration returns [AttributeSetterDefinition declaration]
 tuplePatternStart
     : LBRACKET
       (
-        compilerAnnotations LIDENTIFIER
+        compilerAnnotations PRODUCT_OP? LIDENTIFIER
       |
         (compilerAnnotations declarationStart) => 
         (compilerAnnotations declarationStart)


### PR DESCRIPTION
A tuple pattern may contain only a variadic variable (specified in 298aced). However, the `tuplePatternStart` lookahead rule previously didn’t account for this. The result of this was that the `pattern` rule was unable to parse these patterns, attempting instead an interpretation as `variablePattern`.

This can be seen, for instance, in this code:
```ceylon
value v = let ([*e] = [0]) 0;
```
Without this fix, a syntax error occurs ("extraneous token 'e' expecting closing bracket ']'", interpreting the `[` as the part of a tuple type as in `[Integer] e = [0]`).

Destructuring statements with such patterns already work without this fix because they use the `tupleOrEntryPattern` rule, where the last alternative (chosen if lookahead for `tuplePatternStart` doesn’t match) is `tuplePattern`.

Found in `ceylon.ast`, where in a test `createParser("[*e]").pattern()` strangely returned a `VariablePattern`.

CC @gavinking.