### PR TITLE
Fix #1186: unset line-height for code spans

### DIFF
--- a/en/styles/html.css
+++ b/en/styles/html.css
@@ -83,6 +83,7 @@ PRE, PRE SPAN,
 .synopsis span.emphasis, 
 .literal span.emphasis  {
     font-family: Inconsolata, Monaco, Consolas, "Lucida Console", monospace;
+    line-height: normal; /* overriding 1.40em from another rule, see #1186 */
 }
 
 .screen, .synopsis {


### PR DESCRIPTION
As described in #1186, previously, the spec would scroll up while syntax highlighting was being applied (a lengthy process especially in the html-single version). This happened because as the syntax highlighting is applied, parts of the code (a `<pre>` block) are wrapped in `<span>`s, which (unlike `<pre>`s) receive a line-height of 1.40em (the default is unspecified, but according to MDN roughly 1.2); highlighted code is therefore spaced apart further and takes up more screen space.

Instead of removing the line-height declaration altogether (as I proposed as alternative 3 in the issue), which also affects tables (arguably negatively), we simply override it only in `<span>`s within `<pre>`s, within a rule that already contained another code-specific declaration.

CC @gavinking.