### PR TITLE
Use proper let expressions in operators table

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -2044,23 +2044,12 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
         <para>In the tables, the following pseudo-code is used, which is not legal
         Ceylon syntax:</para>
         
-        <para>First,</para>
-        
         <programlisting>if (b) then x else y   //pseudocode</programlisting>
         
         <para>means the value of <literal>result</literal> after execution of the
         following:</para>
         
         <programlisting>X result; if (b) { result=x; } else { result=y; }</programlisting>
-        
-        <para>Second,</para>
-        
-        <programlisting>let t=x in y   //pseudocode</programlisting>
-        
-        <para>means the value of <literal>result</literal> after execution of the
-        following:</para>
-        
-        <programlisting>X t = x; Y result=y;</programlisting>
     
     </section>
     
@@ -2243,7 +2232,7 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
         <row>
             <entry><literal>lhs in rhs</literal></entry>
             <entry>in</entry>
-            <entry><literal>let x=lhs in rhs.contains(x)</literal></entry>
+            <entry><literal>let (x=lhs) rhs.contains(x)</literal></entry>
             <entry><literal>Object</literal></entry>
             <entry><literal>Category</literal></entry>
             <entry><literal>Boolean</literal></entry>
@@ -2298,19 +2287,19 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
         <itemizedlist>
             <listitem>
                 <para><literal>l&lt;x&lt;u</literal> means 
-                <literal>let t=x in l&lt;t &amp;&amp; t&lt;u</literal>,</para>
+                <literal>let (t=x) l&lt;t &amp;&amp; t&lt;u</literal>,</para>
             </listitem>
             <listitem>
                 <para><literal>l&lt;=x&lt;u</literal> means 
-                <literal>let t=x in l&lt;=t &amp;&amp; t&lt;u</literal>,</para>
+                <literal>let (t=x) l&lt;=t &amp;&amp; t&lt;u</literal>,</para>
             </listitem>
             <listitem>
                 <para><literal>l&lt;x&lt;=u</literal> means 
-                <literal>let t=x in l&lt;t &amp;&amp; t&lt;=u</literal>, and</para>
+                <literal>let (t=x) l&lt;t &amp;&amp; t&lt;=u</literal>, and</para>
             </listitem>
             <listitem>
                 <para><literal>l&lt;=x&lt;=u</literal> means 
-                <literal>let t=x in l&lt;=t &amp;&amp; t&lt;=u</literal></para>
+                <literal>let (t=x) l&lt;=t &amp;&amp; t&lt;=u</literal></para>
             </listitem>
         </itemizedlist>
         


### PR DESCRIPTION
The spec used to define some operators via pseudocode let expressions like this:

    let x=y in e

which, with the introduction of actual let expressions into the language (#747), can instead be written as:

    let (x=y) e

rendering the previous syntax not only obsolete, but also confusing; see for example @PhiLhoSoft on the ceylon-users mailing list https://groups.google.com/d/msg/ceylon-users/N3idC2CZQxI/N_-BaNdydzgJ

CC @gavinking.