### PR TITLE
Update metamodel expressions example

### DIFF
--- a/en/modules/expressions.xml
+++ b/en/modules/expressions.xml
@@ -3175,7 +3175,7 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
         <programlisting>Function&lt;Float,[{Float+}]&gt; sumFunction = `sum&lt;Float&gt;`;</programlisting>
         <programlisting>Attribute&lt;Person,String&gt; personNameAttribute = `Person.name`;</programlisting>
         <programlisting>Method&lt;Person,Anything,[String]&gt; personSayMethod = `Person.say`;</programlisting>
-        <programlisting>Value&lt;Integer&gt; systemMillis = `system.milliseconds`;</programlisting>
+        <programlisting>Attribute&lt;\Isystem,Integer&gt; systemMillis = `\Isystem.milliseconds`;</programlisting>
         
         <para>A <emphasis>constructor metamodel expression</emphasis> is a qualifier, 
         followed by a constructor name, with an optional list of type arguments, 


### PR DESCRIPTION
The syntax `` `a.b` `` is no longer supported (#1243).

CC @gavinking.