### PR TITLE
Document constructor node types

### DIFF
--- a/Ceylon.nodes
+++ b/Ceylon.nodes
@@ -137,12 +137,14 @@
 ^(CLASS_DEFINITION:ANY_CLASS
     CLASS_BODY)
 
+"A value constructor."
 ^(ENUMERATED:DECLARATION
     DELEGATED_CONSTRUCTOR?
     BLOCK
     Value declarationModel;
     Constructor enumerated;)
 
+"A callable constructor."
 ^(CONSTRUCTOR:DECLARATION
     PARAMETER_LIST?
     DELEGATED_CONSTRUCTOR?


### PR DESCRIPTION
`Constructor` is fairly clear, but `Enumerated` isn't at all, as @quintesse can attest to.