### PR TITLE
Add Texinfo support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -36,6 +36,7 @@
     <property name="db.style.fopdf" value="fopdf.xsl"/>
     <property name="db.style.html" value="html_chunk.xsl"/>
     <property name="db.style.htmlsingle" value="html.xsl"/>
+    <property name="db.style.info" value="texinfo.xsl"/>
 
     <!-- Local repository -->
     <property name="ceylon.repo.dir" location="${user.home}/.ceylon/repo"/>
@@ -56,6 +57,11 @@
     <property name="ceylon.module-resolver.dir" value="com/redhat/ceylon/module-resolver/${module.com.redhat.ceylon.module-resolver.version}"/>
     <property name="ceylon.module-resolver.jar" value="${ceylon.module-resolver.dir}/com.redhat.ceylon.module-resolver-${module.com.redhat.ceylon.module-resolver.version}.jar"/>
     <property name="ceylon.module-resolver.lib" location="${ceylon.repo.dir}/${ceylon.module-resolver.jar}"/>
+
+    
+    <condition property="hasInfo">
+      <os family="unix"/>
+    </condition>
 
 
     <!-- Classpath for the build tools. -->
@@ -104,6 +110,17 @@
 
     </target>
 
+    <target name="info"
+            depends="clean.doc"
+            description="Compile Texinfo documentation for all languages.">
+
+        <!-- TRANSLATOR: Duplicate this line for your language -->
+        <antcall target="lang.docinfo">
+            <param name="lang" value="en"/>
+        </antcall>
+
+    </target>
+
     <target name="revdiff"
             description="Generates a diff report for all translated versions.">
 
@@ -135,6 +152,7 @@
         <antcall target="lang.dochtml"/>
         <antcall target="lang.dochtmlsingle"/>
         <antcall target="lang.htmlmisc"/>
+        <antcall target="lang.docinfo"/>
     </target>
 
 
@@ -293,6 +311,44 @@
             </fileset>
         </copy>
 
+    </target>
+
+    <target name="lang.docinfo.texi">
+
+        <mkdir dir="${build.dir}/${lang}/info/"/>
+
+        <java classname="com.icl.saxon.StyleSheet" fork="true" dir="${basedir}" maxmemory="192m">
+            <classpath refid="lib.classpath"/>
+            <arg value="-o"/>
+            <arg value="${build.dir}/${lang}/info/ceylon-spec.texi"/>
+            <arg value="${basedir}/${lang}/master.xml"/>
+            <arg value="${basedir}/${lang}/styles/${db.style.info}"/>
+        </java>
+
+    </target>
+
+    <target name="lang.docinfo.make" if="hasInfo">
+
+        <exec executable="makeinfo" dir="${build.dir}/${lang}/info/">
+            <arg value="ceylon-spec.texi"/>
+        </exec>
+      
+    </target>
+
+    <target name="lang.docinfo"
+            depends="lang.docinfo.texi,lang.docinfo.make"
+            description="Generates the Texinfo documentation only for a language (set lang)"/>
+
+    <target name="lang.docinfo.install"
+            depends="lang.docinfo"
+            if="hasInfo">
+
+        <exec executable="sudo" dir="${build.dir}/${lang}/info/">
+            <arg value="sh"/>
+            <arg value="-c"/>
+            <arg value="install --owner=root --group=root --mode=0644 ceylon-spec.info* /usr/share/info &amp;&amp; install-info --info-dir=/usr/share/info /usr/share/info/ceylon-spec.info"/>
+        </exec>
+      
     </target>
 
     <target name="lang.revdiff"

--- a/en/modules/declarations.xml
+++ b/en/modules/declarations.xml
@@ -1001,7 +1001,7 @@ TypeConstraints?
         
         </section>
         
-        <section>
+        <section id="dynamicinterfaces">
             <title>Dynamic interfaces</title>
             
             <para>A <emphasis>dynamic interface</emphasis> is an interface declared with the 

--- a/en/modules/execution.xml
+++ b/en/modules/execution.xml
@@ -239,7 +239,7 @@ void run() {
         or when an exception is thrown by an evaluation, assignment, invocation, or 
         instantiation.</para>
         
-        <section>
+        <section id="frames">
             <title>Frames</title>
         
             <para>When execution of a body begins, a <emphasis>frame</emphasis> is created.
@@ -294,7 +294,7 @@ void run() {
         
         </section>
         
-        <section>
+        <section id="currentinstancesandcurrentframes">
             <title>Current instances and current frames</title>
             
             <para>A frame may be the <emphasis>current frame</emphasis> for a body. When the 
@@ -586,7 +586,7 @@ String result = middleObject.string;</programlisting>
             
         </section>
         
-        <section if="lateinitialization">
+        <section id="lateinitialization">
             <title>Initialization of late references</title>
             
             <para>A reference annotated <literal>late</literal> may be uninitialized in a 

--- a/support/docbook-xsl/texinfo/block.xsl
+++ b/support/docbook-xsl/texinfo/block.xsl
@@ -1,0 +1,48 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exsl="http://exslt.org/common"
+                exclude-result-prefixes="exsl"
+                version='1.0'>
+
+<xsl:template match="para">
+  <xsl:apply-templates/>
+  <xsl:text> <!-- explicit blank line -->
+
+  </xsl:text>
+</xsl:template>
+
+<xsl:template match="itemizedlist">
+  @itemize @bullet
+  <xsl:apply-templates/>
+  @end itemize
+</xsl:template>
+
+<xsl:template match="listitem">
+  @item <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="comment">
+@smallindentedblock
+  <xsl:apply-templates/>
+@end smallindentedblock
+</xsl:template>
+
+<xsl:template match="programlisting">
+@example
+<xsl:apply-templates/>
+@end example
+</xsl:template>
+
+<xsl:template match="screen">
+@quotation
+ <xsl:apply-templates/>
+@end quotation
+</xsl:template>
+
+<xsl:template match="synopsis">
+@verbatim
+<xsl:value-of select="."/>
+@end verbatim
+</xsl:template>
+
+</xsl:stylesheet>

--- a/support/docbook-xsl/texinfo/docbook.xsl
+++ b/support/docbook-xsl/texinfo/docbook.xsl
@@ -1,0 +1,30 @@
+<?xml version='1.0'?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exsl="http://exslt.org/common"
+                exclude-result-prefixes="exsl"
+                version='1.0'>
+
+<xsl:output method="text"
+            encoding="ISO-8859-1"
+            indent="no"/>
+
+<xsl:include href="../VERSION"/>
+<xsl:include href="param.xsl"/>
+<xsl:include href="empty.xsl"/>
+<xsl:include href="text.xsl"/>
+<xsl:include href="inline.xsl"/>
+<xsl:include href="block.xsl"/>
+<xsl:include href="structure.xsl"/>
+<xsl:include href="../lib/lib.xsl"/>
+<xsl:include href="../common/l10n.xsl"/>
+<xsl:include href="../common/common.xsl"/>
+<xsl:include href="../common/titles.xsl"/>
+
+<xsl:param name="stylesheet.result.type" select="'texinfo'"/>
+
+<xsl:key name="id" match="*" use="@id"/>
+
+<xsl:template match="/"><xsl:apply-templates/></xsl:template>
+
+</xsl:stylesheet>

--- a/support/docbook-xsl/texinfo/empty.xsl
+++ b/support/docbook-xsl/texinfo/empty.xsl
@@ -1,0 +1,11 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exsl="http://exslt.org/common"
+                exclude-result-prefixes="exsl"
+                version='1.0'>
+
+<xsl:template match="bookinfo"/>
+<xsl:template match="title"/>
+<xsl:template match="toc"/>
+
+</xsl:stylesheet>

--- a/support/docbook-xsl/texinfo/inline.xsl
+++ b/support/docbook-xsl/texinfo/inline.xsl
@@ -1,0 +1,12 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exsl="http://exslt.org/common"
+                exclude-result-prefixes="exsl"
+                version='1.0'>
+
+<xsl:template match="literal">@code{<xsl:apply-templates/>}</xsl:template>
+<xsl:template match="emphasis">@emph{<xsl:value-of select="."/>}</xsl:template>
+<xsl:template match="xref">@ref{<xsl:value-of select="@linkend"/>, ,<xsl:value-of select="key('id',@linkend)[1]/title"/>}</xsl:template>
+<xsl:template match="filename">@file{<xsl:value-of select="."/>}</xsl:template>
+
+</xsl:stylesheet>

--- a/support/docbook-xsl/texinfo/param.xsl
+++ b/support/docbook-xsl/texinfo/param.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains a bunch of params and templates that we don't care about, but the runtime needs. -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:src="http://nwalsh.com/xmlns/litprog/fragment" exclude-result-prefixes="src" version="1.0">
+
+<xsl:template name="is.graphic.format"><xsl:param name="format"/>0</xsl:template>
+<xsl:template name="is.graphic.extension"><xsl:param name="format"/>0</xsl:template>
+<xsl:template name="write.chunk"/>
+<xsl:template name="href.target"/>
+<xsl:template name="xref.xreflabel"/>
+
+<xsl:param name="appendix.autolabel" select="1"/>
+<xsl:param name="author.othername.in.middle" select="1"/>
+<xsl:param name="chapter.autolabel" select="1"/>
+<xsl:param name="collect.xref.targets" select="'no'"/>
+<xsl:param name="formal.procedures" select="1"/>
+<xsl:param name="graphic.default.extension"/>
+<xsl:param name="l10n.gentext.default.language" select="'en'"/>
+<xsl:param name="l10n.gentext.language" select="''"/>
+<xsl:param name="l10n.gentext.use.xref.language" select="0"/>
+<xsl:param name="olink.base.uri" select="''"/>
+<xsl:param name="part.autolabel" select="1"/>
+<xsl:param name="preface.autolabel" select="0"/>
+<xsl:param name="preferred.mediaobject.role"/>
+<xsl:param name="punct.honorific" select="'.'"/>
+<xsl:param name="qanda.defaultlabel">number</xsl:param>
+<xsl:param name="qanda.inherit.numeration" select="1"/>
+<xsl:param name="qandadiv.autolabel" select="1"/>
+<xsl:param name="section.autolabel" select="0"/>
+<xsl:param name="section.label.includes.component.label" select="0"/>
+<xsl:param name="targets.filename" select="'target.db'"/>
+<xsl:param name="tex.math.in.alt" select="''"/>
+<xsl:param name="use.role.for.mediaobject" select="1"/>
+<xsl:param name="use.svg" select="1"/>
+<xsl:param name="xref.with.number.and.title" select="1"/>
+<xsl:param name="xref.label-title.separator">: </xsl:param>
+<xsl:param name="xref.label-page.separator"><xsl:text> </xsl:text></xsl:param>
+<xsl:param name="xref.title-page.separator"><xsl:text> </xsl:text></xsl:param>
+<xsl:param name="insert.xref.page.number">no</xsl:param>
+</xsl:stylesheet>

--- a/support/docbook-xsl/texinfo/structure.xsl
+++ b/support/docbook-xsl/texinfo/structure.xsl
@@ -1,0 +1,203 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exsl="http://exslt.org/common"
+                exclude-result-prefixes="exsl"
+                version='1.0'>
+
+<xsl:template match="book">
+  <xsl:param name="node" select="."/>
+  <xsl:param name="title" select="./bookinfo/title"/>
+  <xsl:param name="subtitle" select="./bookinfo/subtitle"/>
+  <xsl:param name="version" select="./bookinfo/releaseinfo"/>
+  <xsl:param name="author" select="concat(./bookinfo/author/firstname, ' ', ./bookinfo/author/surname)"/>
+\input texinfo
+@setfilename ceylon-spec.info
+@settitle <xsl:value-of select="$title"/>
+@dircategory Software development
+@direntry
+* Ceylon: (ceylon-spec).       The Ceylon Language Specification.
+@end direntry
+@codequotebacktick on
+
+@copying
+This is the Ceylon Language Specification, version <xsl:value-of select="$version"/>.
+
+Copyright @copyright{} 2008--2015 <xsl:value-of select="$author"/> and contributors
+
+@quotation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+@end quotation
+@end copying
+
+@titlepage
+@title <xsl:value-of select="$title"/>
+@subtitle <xsl:value-of select="$subtitle"/>
+
+@page
+@vskip 0pt plus 1filll
+@insertcopying
+@end titlepage
+
+@contents
+
+@ifnottex
+@node Top
+@top <xsl:value-of select="$title"/>
+
+This is the Ceylon Language Specification, version <xsl:value-of select="$version"/>.
+@end ifnottex
+
+@menu
+* preface:: Welcome to Ceylon.<xsl:for-each select="/book/chapter"> <!-- needs to be on one line -->
+    <xsl:variable name="chaptitle"><xsl:apply-templates select="." mode="title.markup"/></xsl:variable>
+    <xsl:variable name="chapid" select="@id"/>
+* <xsl:value-of select="$chapid"/>:: <xsl:value-of select="$chaptitle"/>
+  </xsl:for-each>
+* index:: Complete index.
+@end menu
+
+<xsl:apply-templates/>
+
+@node index
+@unnumbered Index
+
+@printindex cp
+
+@bye
+</xsl:template>
+
+<xsl:template match="chapter">
+  <xsl:variable name="id" select="@id"/>
+  <xsl:variable name="title"><xsl:apply-templates select="." mode="title.markup"/></xsl:variable>
+@node <xsl:value-of select="$id"/>
+@chapter <xsl:value-of select="$title"/>
+@cindex <xsl:value-of select="$title"/>
+
+@menu
+  <xsl:for-each select="./section">
+    <xsl:variable name="sectitle"><xsl:apply-templates select="." mode="title.markup"/></xsl:variable>
+    <xsl:variable name="secid" select="@id"/>
+* <xsl:value-of select="$secid"/>:: <xsl:value-of select="$sectitle"/>
+  </xsl:for-each>
+@end menu
+
+  <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="section">
+  <xsl:variable name="depth" select="count(ancestor::section)+1"/>
+  <xsl:variable name="id" select="@id"/>
+  <xsl:variable name="title"><xsl:apply-templates select="." mode="title.markup"/></xsl:variable>
+@node <xsl:value-of select="$id"/>
+  <xsl:choose>
+    <xsl:when test="$depth=1">
+@section <xsl:value-of select="$title"/>
+    </xsl:when>
+    <xsl:when test="$depth=2">
+@subsection <xsl:value-of select="$title"/>
+    </xsl:when>
+    <xsl:when test="$depth=3">
+@subsubsection <xsl:value-of select="$title"/>
+    </xsl:when>
+  </xsl:choose>
+@cindex <xsl:value-of select="$title"/>
+  <xsl:text><!-- explicit blank line needed -->
+
+  </xsl:text>
+
+  <xsl:choose>
+    <xsl:when test="count(./section) > 0">
+      <!-- we have subsections, let's make a menu -->
+@menu
+      <xsl:for-each select="./section">
+        <xsl:variable name="sectitle"><xsl:apply-templates select="." mode="title.markup"/></xsl:variable>
+        <xsl:variable name="secid" select="@id"/>
+* <xsl:value-of select="$secid"/>:: <xsl:value-of select="$sectitle"/>
+      </xsl:for-each>
+@end menu
+
+      <xsl:apply-templates/>
+    </xsl:when>
+    <xsl:otherwise>
+      <!-- no subsections, no menu -->
+      <xsl:apply-templates/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template match="preface">
+  <xsl:variable name="id" select="@id"/>
+  <xsl:variable name="title">
+    <xsl:apply-templates select="." mode="title.markup"/>
+  </xsl:variable>
+@node preface
+@unnumbered Preface
+@cindex Preface
+<xsl:text> <!-- explicit blank line -->
+  
+</xsl:text>
+  <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="@colwidth">
+  <xsl:value-of select="substring-before(., '*')"/>
+</xsl:template>
+
+<xsl:template match="table/tgroup">
+  <!--
+      Okay, so about the column widths.
+      The colspec/@colwidth attributes look like: 1.5* 7* 2.3* etc.
+      To turn this into fractional widths, we would need to form their sums.
+      The sum() function does that… but of course not with that asterisk at the end.
+      Problem is, as soon as we do anything to remove the asterisk (for-each or something),
+      it’s no longer a node set, it’s just a concatenated string "1.572.3".
+      I have found no way to work around this, so we’re just hardcoding the widths
+      of the two tables that occur in the Ceylon spec.
+      Sorry.
+
+<xsl:variable name="colwidths-ast" select="colspec/@colwidth"/>
+<xsl:variable name="colwidths"><xsl:for-each select="$colwidths-ast"><xsl:value-of select="number(substring-before(., '*'))"/></xsl:for-each></xsl:variable>
+@multitable <xsl:for-each select="$colwidths"><xsl:value-of select="concat(' ', $colwidths)"/></xsl:for-each>
+  -->
+  <xsl:choose>
+    <xsl:when test="count(colspec) = 4">
+@multitable {Comparison, containment, assignability, inheritance:} {@code{=}, @code{+=}, @code{-=}, @code{*=}, @code{/=}, @code{%=}, @code{&amp;=}, @code{|=}, @code{~=}, @code{&amp;&amp;=}, @code{||=}} {Binary (and ternary)} {Associativity}
+    </xsl:when>
+    <xsl:when test="count(colspec) = 6">
+@multitable {@code{lhs[from:length]}} {lower spanned subrange} {@code{compose((Iterable&lt;T,N&gt; ts)=>[*ts], lhs.spread(X.method))}} {any subtype of @code{Anything[]?} whose intersections with @code{[]} and @code{[Nothing+]} are not @code{Nothing}} {@code{Y given Y satisfies Identifiable} where @code{X&amp;Y} is not @code{Nothing}} {@code{[T*](*P)} or @code{[T+](*P)}}
+    </xsl:when>
+    <xsl:otherwise>
+@multitable @columnfractions <xsl:for-each select="tgroup/colspec"><xsl:value-of select="1 div count(../colspec)"/></xsl:for-each>
+    </xsl:otherwise>
+  </xsl:choose>
+  <xsl:for-each select="thead/row">
+@headitem
+    <xsl:apply-templates select="entry[position()=1]"/>
+    <xsl:for-each select="entry[position()>1]">
+@tab <xsl:apply-templates select="."/>
+    </xsl:for-each>
+  </xsl:for-each>
+  <xsl:for-each select="tbody/row">
+@item
+    <xsl:apply-templates select="entry[position()=1]"/>
+    <xsl:for-each select="entry[position()>1]">
+@tab <xsl:apply-templates select="."/>
+    </xsl:for-each>
+  </xsl:for-each>
+@end multitable
+</xsl:template>
+
+<xsl:template match="table"><xsl:apply-templates select="tgroup"/></xsl:template>
+<xsl:template match="entry"><xsl:apply-templates select="child::node()"/></xsl:template>
+
+</xsl:stylesheet>

--- a/support/docbook-xsl/texinfo/text.xsl
+++ b/support/docbook-xsl/texinfo/text.xsl
@@ -1,0 +1,96 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exsl="http://exslt.org/common"
+                exclude-result-prefixes="exsl"
+                version='1.0'>
+
+<xsl:template name="escape">
+  <xsl:param name="text" select="."/>
+  <xsl:variable name="text-escaped-at">
+    <xsl:call-template name="string-replace-all">
+      <xsl:with-param name="text" select="$text"/>
+      <xsl:with-param name="replace" select="'@'"/>
+      <xsl:with-param name="by" select="'@@'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="text-escaped-lbrace">
+    <xsl:call-template name="string-replace-all">
+      <xsl:with-param name="text" select="$text-escaped-at"/>
+      <xsl:with-param name="replace" select="'{'"/>
+      <xsl:with-param name="by" select="'@{'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="text-escaped-rbrace">
+    <xsl:call-template name="string-replace-all">
+      <xsl:with-param name="text" select="$text-escaped-lbrace"/>
+      <xsl:with-param name="replace" select="'}'"/>
+      <xsl:with-param name="by" select="'@}'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:value-of select="$text-escaped-rbrace"/>
+</xsl:template>
+
+<xsl:template name="fix-entities">
+  <xsl:param name="text" select="."/>
+  <xsl:variable name="text-fixed-mdash">
+    <xsl:call-template name="string-replace-all">
+      <xsl:with-param name="text" select="$text"/>
+      <xsl:with-param name="replace" select="'&#8212;'"/>
+      <xsl:with-param name="by" select="'---'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="text-fixed-lquot">
+    <xsl:call-template name="string-replace-all">
+      <xsl:with-param name="text" select="$text-fixed-mdash"/>
+      <xsl:with-param name="replace" select="'&#8220;'"/>
+      <xsl:with-param name="by" select="'@quotedblleft{}'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="text-fixed-rquot">
+    <xsl:call-template name="string-replace-all">
+      <xsl:with-param name="text" select="$text-fixed-lquot"/>
+      <xsl:with-param name="replace" select="'&#8221;'"/>
+      <xsl:with-param name="by" select="'@quotedblright{}'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:value-of select="$text-fixed-rquot"/>
+</xsl:template>
+
+<xsl:template match="text()">
+  <xsl:variable name="text" select="."/>
+  <xsl:variable name="text-escaped">
+    <xsl:call-template name="escape">
+      <xsl:with-param name="text" select="$text"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="text-fixed">
+    <xsl:call-template name="fix-entities">
+      <xsl:with-param name="text" select="$text-escaped"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:value-of select="$text-fixed"/>
+</xsl:template>
+
+<!-- source: https://stackoverflow.com/a/3067130/1420237 -->
+<xsl:template name="string-replace-all">
+  <xsl:param name="text" />
+  <xsl:param name="replace" />
+  <xsl:param name="by" />
+  <xsl:choose>
+    <xsl:when test="contains($text, $replace)">
+      <xsl:value-of select="substring-before($text,$replace)" />
+      <xsl:value-of select="$by" />
+      <xsl:call-template name="string-replace-all">
+        <xsl:with-param name="text"
+                        select="substring-after($text,$replace)" />
+        <xsl:with-param name="replace" select="$replace" />
+        <xsl:with-param name="by" select="$by" />
+      </xsl:call-template>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="$text" />
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
I wrote some XSLT stylesheets that transform the spec’s Docbook into Texinfo.

To test it, run:

    ant -Dlang.en lang.docinfo.install

and then you can view the specification with

    info ceylon-spec

or

    emacs # open emacs
    C-h i # open info directory
    mCeylon # menu item Ceylon

We could also add Texinfo→HTML and Texinfo→PDF transformation, but that’s kinda pointless, since we already have those two formats, and the Texinfo version looks worse.

Note: this pull request also contains the commit from #1407 (closes #1407), since it’s required for this to work (all nodes need to have IDs).