### PR TITLE
use headless mode for pdf generation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -201,6 +201,7 @@
         <!-- Create a PDF from the XSL/FO. -->
         <java classname="org.apache.fop.apps.Fop" fork="true" dir="${basedir}" maxmemory="192m">
             <classpath refid="lib.classpath"/>
+            <jvmarg value="-Djava.awt.headless=true"/>
             <arg value="${build.dir}/${lang}/pdf/docbook_fop.tmp"/>
             <arg value="${build.dir}/${lang}/pdf/${docname}.pdf"/>
         </java>


### PR DESCRIPTION
This avoids the loss of GUI focus during PDF generation. On OS X (and others) the short-lived Java GUI app icon no longer appears with this change.